### PR TITLE
explicitly enforce CRLF (windows style line endings) via git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.go text eol=crlf


### PR DESCRIPTION
to avoid diff mangling from go fmt 
