### PR TITLE
Increase custom feature limit from 20 to 58

### DIFF
--- a/user.go
+++ b/user.go
@@ -18,7 +18,7 @@ type userTools struct {
 	nicklookup  map[string]*uidprot
 	nicklock    sync.RWMutex
 	featurelock sync.RWMutex
-	features    map[uint32][]string
+	features    map[uint64][]string
 }
 
 var (
@@ -26,7 +26,7 @@ var (
 		nicklookup:  make(map[string]*uidprot),
 		nicklock:    sync.RWMutex{},
 		featurelock: sync.RWMutex{},
-		features:    make(map[uint32][]string),
+		features:    make(map[uint64][]string),
 	}
 )
 
@@ -99,7 +99,7 @@ type Userid int32
 type User struct {
 	id              Userid
 	nick            string
-	features        uint32
+	features        uint64
 	lastmessage     []byte
 	lastmessagetime time.Time
 	delayscale      uint8
@@ -152,11 +152,11 @@ func userfromSession(m []byte) (u *User) {
 	return
 }
 
-func (u *User) featureGet(bitnum uint32) bool {
+func (u *User) featureGet(bitnum uint64) bool {
 	return ((u.features & bitnum) != 0)
 }
 
-func (u *User) featureSet(bitnum uint32) {
+func (u *User) featureSet(bitnum uint64) {
 	u.features |= bitnum
 }
 
@@ -248,7 +248,7 @@ func (u *User) assembleSimplifiedUser() {
 			f = append(f, "bot")
 		}
 
-		for i := uint8(6); i < 32; i++ {
+		for i := uint8(6); i < 64; i++ {
 			if u.featureGet(1 << i) {
 				flair := fmt.Sprintf("flair%d", i-5)
 				f = append(f, flair)

--- a/user.go
+++ b/user.go
@@ -212,7 +212,7 @@ func (u *User) setFeatures(features []string) {
 					continue
 				}
 				// six proper features, all others are just useless flairs
-				u.featureSet(1 << (6 + uint8(flair)))
+				u.featureSet(1 << (5 + uint8(flair)))
 			}
 		}
 	}
@@ -248,9 +248,9 @@ func (u *User) assembleSimplifiedUser() {
 			f = append(f, "bot")
 		}
 
-		for i := uint8(6); i <= 26; i++ {
+		for i := uint8(6); i < 32; i++ {
 			if u.featureGet(1 << i) {
-				flair := fmt.Sprintf("flair%d", i-6)
+				flair := fmt.Sprintf("flair%d", i-5)
 				f = append(f, flair)
 			}
 		}


### PR DESCRIPTION
Whether or not a user has a particular feature (aka flair) in chat is determined by the state of its bit in [`features`](https://github.com/destinygg/chat/blob/ae4252a200427e4dafda75517be0fdc31ec318e3/user.go#L102), a `uint32` that serves as a bit field. The six least significant bits [are reserved for "important" features](https://github.com/destinygg/chat/blob/ae4252a200427e4dafda75517be0fdc31ec318e3/user.go#L33-L40): `admin`, `moderator`, `vip`, `protected`, `subscriber`, and `bot`.

```
const (
	ISADMIN      = 1 << iota // ...00000001
	ISMODERATOR  = 1 << iota // ...00000010
	ISVIP        = 1 << iota // ...00000100
	ISPROTECTED  = 1 << iota // ...00001000
	ISSUBSCRIBER = 1 << iota // ...00010000
	ISBOT        = 1 << iota // ...00100000
)
```

The remaining 26 bits [are used for other, "useless" features](https://github.com/destinygg/chat/blob/ae4252a200427e4dafda75517be0fdc31ec318e3/user.go#L207-L216). These features must have a `featureName` (not to be confused with `featureLabel`, a user-readable title) in the format `flair<number>`. This condition is (somewhat) enforced by [`FlairService.findAvailableFlairNames()`](https://github.com/destinygg/website/blob/eddfdc733b8109854b4a9fe29bd793b10060bab6/lib/Destiny/Chat/FlairService.php#L186-L199), which returns an array of available `featureName`s in said format when creating a new feature.

The obvious problem with this is a `uint32` doesn't have enough bits to accommodate features with a `featureName` greater than `flair26`, a limit we've already hit. Additionally, the limit is actually `flair20` because of a bug [here](https://github.com/destinygg/chat/blob/ae4252a200427e4dafda75517be0fdc31ec318e3/user.go#L251) where the loop only checks features up to the 27th bit and a bug [here](https://github.com/destinygg/chat/blob/ae4252a200427e4dafda75517be0fdc31ec318e3/user.go#L215) that shifts by 6 when it should only shift by 5 to account for the important features. It's possible the author thought the first custom feature starts at `flair0` when it actually starts at `flair1`.

This PR changes the `uint32` to a `uint64`. We can revisit this issue if there ever comes a time where we need more than 64 features at once, which seems unlikely (famous last words).

As a side note, `FlairService.findAvailableFlairNames()` only returns `featureName`s up to `flair64`. This makes me think the author of the function assumed the `features` field is a `uint64`. Even so, the max `featureName` with a `uint64` is `flair58` because of the important features.