### PR TITLE
Fix WebSocket upgrade CSRF vulnerability

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ var (
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin:     func(r *http.Request) bool { return true },
 }
 
 const (


### PR DESCRIPTION
For WebSocket upgrade requests, `gorilla/websocket` calls `CheckOrigin` to determine if the upgrade should be performed. The function should "carefully validate the request origin to prevent cross-site request forgery".

The current implementation immediately returns `true`, essentially performing no check. If undefined, a ["safe default"](https://github.com/gorilla/websocket/blob/b65e62901fc1c0d968042419e74789f6af455eb9/server.go#L86-L97) is used, which only upgrades the request if the host component of the `Origin` header matches the `Host` header.

This PR removes the current implementation so the default is used.