### PR TITLE
Update error events to carry additional properties

### DIFF
--- a/build
+++ b/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-go build $1 -o chat main.go data.go mutes.go bans.go user.go user_ffjson.go hub.go connection.go debug.go cache.go database.go api.go namescache.go namescache_ffjson.go
+go build $1 -o chat main.go data.go mutes.go bans.go user.go user_ffjson.go hub.go connection.go debug.go cache.go database.go api.go namescache.go namescache_ffjson.go errors.go

--- a/connection.go
+++ b/connection.go
@@ -89,6 +89,10 @@ type PrivmsgOut struct {
 	Data      string `json:"data,omitempty"`
 }
 
+type GenericError struct {
+	Description string `json:"description"`
+}
+
 // Create a new connection using the specified socket and router.
 func newConnection(s *websocket.Conn, user *User, ip string) {
 	c := &Connection{

--- a/connection.go
+++ b/connection.go
@@ -213,7 +213,7 @@ func (c *Connection) writePumpText() {
 				return
 			}
 		case <-c.banned:
-			c.write(websocket.TextMessage, []byte(`ERR "banned"`))
+			c.write(websocket.TextMessage, []byte(`ERR {"description":"banned"}`))
 			c.write(websocket.CloseMessage, []byte{})
 			return
 		case <-c.stop:
@@ -681,7 +681,7 @@ func (c *Connection) OnPong(data []byte) {
 }
 
 func (c *Connection) SendError(identifier string) {
-	c.EmitBlock("ERR", identifier)
+	c.EmitBlock("ERR", GenericError{identifier})
 }
 
 func (c *Connection) Refresh() {

--- a/connection.go
+++ b/connection.go
@@ -157,6 +157,18 @@ func (c *Connection) readPumpText() {
 	c.Names()
 	c.Join() // broadcast to the chat that a user has connected
 
+	// Check mute status.
+	muteTimeLeft := mutes.muteTimeLeft(c)
+	if muteTimeLeft > time.Duration(0) {
+		c.EmitBlock(
+			"ERR",
+			MutedError{
+				GenericError{"muted"},
+				int64(muteTimeLeft / time.Second),
+			},
+		)
+	}
+
 	for {
 		msgtype, message, err := c.socket.ReadMessage()
 		if err != nil || msgtype == websocket.BinaryMessage {

--- a/connection.go
+++ b/connection.go
@@ -90,15 +90,6 @@ type PrivmsgOut struct {
 	Data      string `json:"data,omitempty"`
 }
 
-type GenericError struct {
-	Description string `json:"description"`
-}
-
-type MutedError struct {
-	GenericError
-	MuteTimeLeft int64 `json:"muteTimeLeft"`
-}
-
 // Create a new connection using the specified socket and router.
 func newConnection(s *websocket.Conn, user *User, ip string) {
 	c := &Connection{
@@ -161,13 +152,7 @@ func (c *Connection) readPumpText() {
 	// Check mute status.
 	muteTimeLeft := mutes.muteTimeLeft(c)
 	if muteTimeLeft > time.Duration(0) {
-		c.EmitBlock(
-			"ERR",
-			MutedError{
-				GenericError{"muted"},
-				int64(muteTimeLeft / time.Second),
-			},
-		)
+		c.EmitBlock("ERR", NewMutedError(muteTimeLeft))
 	}
 
 	for {
@@ -408,13 +393,7 @@ func (c *Connection) canMsg(msg string, ignoresilence bool) bool {
 	if !ignoresilence {
 		muteTimeLeft := mutes.muteTimeLeft(c)
 		if muteTimeLeft > time.Duration(0) {
-			c.EmitBlock(
-				"ERR",
-				MutedError{
-					GenericError{"muted"},
-					int64(muteTimeLeft / time.Second),
-				},
-			)
+			c.EmitBlock("ERR", NewMutedError(muteTimeLeft))
 			return false
 		}
 

--- a/connection.go
+++ b/connection.go
@@ -55,6 +55,7 @@ type EventDataOut struct {
 	Timestamp    int64  `json:"timestamp"`
 	Data         string `json:"data,omitempty"`
 	Extradata    string `json:"extradata,omitempty"`
+	Duration     int64  `json:"duration,omitempty"`
 }
 
 type BanIn struct {
@@ -556,6 +557,7 @@ func (c *Connection) OnMute(data []byte) {
 	mutes.muteUserid(uid, mute.Duration)
 	out := c.getEventDataOut()
 	out.Data = mute.Data
+	out.Duration = mute.Duration / int64(time.Second)
 	out.Targetuserid = uid
 	c.Broadcast("MUTE", out)
 }

--- a/connection.go
+++ b/connection.go
@@ -384,7 +384,7 @@ func (c *Connection) canMsg(msg string, ignoresilence bool) bool {
 	}
 
 	if !ignoresilence {
-		if mutes.isUserMuted(c) {
+		if mutes.muteTimeLeft(c) > time.Duration(0) {
 			c.SendError("muted")
 			return false
 		}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"time"
+)
+
+type GenericError struct {
+	Description string `json:"description"`
+}
+
+type MutedError struct {
+	GenericError
+	MuteTimeLeft int64 `json:"muteTimeLeft"`
+}
+
+func NewMutedError(duration time.Duration) MutedError {
+	return MutedError{
+		GenericError{"muted"},
+		int64(duration / time.Second),
+	}
+}

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func main() {
 
 		if banned {
 			ws.SetWriteDeadline(time.Now().Add(WRITETIMEOUT))
-			ws.WriteMessage(websocket.TextMessage, []byte(`ERR "banned"`))
+			ws.WriteMessage(websocket.TextMessage, []byte(`ERR {"description":"banned"}`))
 			return
 		}
 

--- a/mutes.go
+++ b/mutes.go
@@ -36,17 +36,19 @@ func (m *Mutes) unmuteUserid(uid Userid) {
 	state.save()
 }
 
-func (m *Mutes) isUserMuted(c *Connection) bool {
+func (m *Mutes) muteTimeLeft(c *Connection) time.Duration {
 	if c.user == nil {
-		return true
+		return time.Duration(0)
 	}
 
 	state.Lock()
 	defer state.Unlock()
 
-	t, ok := state.mutes[c.user.id]
+	muteExpirationTime, ok := state.mutes[c.user.id]
 	if !ok {
-		return false
+		return time.Duration(0)
 	}
-	return !isExpiredUTC(t)
+
+	timeLeft := time.Until(muteExpirationTime)
+	return timeLeft
 }

--- a/mutes_test.go
+++ b/mutes_test.go
@@ -14,11 +14,11 @@ func TestMuteTimes(t *testing.T) {
 	c.user.id = uid
 
 	state.mutes[uid] = timeinfuture
-	if !mutes.isUserMuted(c) {
+	if !(mutes.muteTimeLeft(c) > time.Duration(0)) {
 		t.Error("user should be banned because the expiretime is in the future")
 	}
 	state.mutes[uid] = timeinpast
-	if mutes.isUserMuted(c) {
+	if mutes.muteTimeLeft(c) > time.Duration(0) {
 		t.Error("user should NOT be banned because the expiretime is in the past")
 	}
 


### PR DESCRIPTION
This PR sets the foundation for a better user experience when it comes to mutes. In doing so, a backwards-incompatible change to error events was introduced. Projects that connect to chat may break when this PR is merged and deployed.

1. The payload for error (`ERR`) events is no longer a simple string, but a JSON object. After parsing the payload, the error message will be accessible via the `description` key. Put simply, `ERR "errormessage"` becomes `ERR {"description":"errormessage"}`.

2. Payloads for incoming mute (`MUTE`) events now provide the duration of the mute in seconds, accessible via `duration`.

3. `muted` error event payloads contain the mute time left in seconds, accessible via `muteTimeLeft`.

3. Muted users will receive a `muted` error shortly after they connect to chat.