### PR TITLE
Cache list of connected chat users in Redis

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -231,3 +231,14 @@ func cacheChatEvent(msg *message) {
 		D("cacheChatEvent redis error", err)
 	}
 }
+
+func cacheConnectedUsers(marshallednames []byte) {
+	conn := redisGetConn()
+	defer conn.Return()
+
+	_, err := conn.DoOK("SET", "CHAT:connectedUsers", marshallednames)
+
+	if err != nil {
+		D("Error caching connected users.", err)
+	}
+}

--- a/namescache.go
+++ b/namescache.go
@@ -93,6 +93,8 @@ func (nc *namesCache) marshalNames(updateircnames bool) {
 	}
 	nc.marshallednames, _ = n.MarshalJSON()
 
+	cacheConnectedUsers(nc.marshallednames)
+
 	for _, u := range nc.users {
 		u.RUnlock()
 	}


### PR DESCRIPTION
When a user connects to chat, the server delivers a JSON-encoded string that contains the number of connections it's managing and an array of all connected users via a `NAMES` event. With this PR, we also store the string in Redis so we can fetch it from destinygg/website.