### PR TITLE
Add option for allowed origin host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ settings.cfg
 *.sublime-*
 deploy.sh
 *.pprof
-.state.dc
+state.dc
 /.idea

--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func (s *State) load() {
 	s.Lock()
 	defer s.Unlock()
 
-	b, err := ioutil.ReadFile(".state.dc")
+	b, err := ioutil.ReadFile("state.dc")
 	if err != nil {
 		D("Error while reading from states file", err)
 		return
@@ -219,7 +219,7 @@ func (s *State) save() {
 		D("Error encoding submode:", err)
 	}
 
-	err = ioutil.WriteFile(".state.dc", mb.Bytes(), 0600)
+	err = ioutil.WriteFile("state.dc", mb.Bytes(), 0600)
 	if err != nil {
 		D("Error with writing out state file:", err)
 	}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 		nc.AddOption("default", "maxprocesses", "0")
 		nc.AddOption("default", "chatdelay", fmt.Sprintf("%d", 300*time.Millisecond))
 		nc.AddOption("default", "maxthrottletime", fmt.Sprintf("%d", 5*time.Minute))
+		nc.AddOption("default", "allowedoriginhost", "localhost")
 
 		nc.AddSection("redis")
 		nc.AddOption("redis", "address", "localhost:6379")
@@ -94,6 +95,7 @@ func main() {
 	processes, _ := c.GetInt64("default", "maxprocesses")
 	delay, _ := c.GetInt64("default", "chatdelay")
 	maxthrottletime, _ := c.GetInt64("default", "maxthrottletime")
+	allowedoriginhost, _ := c.GetString("default", "allowedoriginhost")
 	apiurl, _ := c.GetString("api", "url")
 	apikey, _ := c.GetString("api", "key")
 	DELAY = time.Duration(delay)


### PR DESCRIPTION
This PR adds a new option to `settings.cfg` that specifies a permissible value for the `Origin` header's host in WebSocket requests. The value is used in `CheckOrigin`, a function called by gorilla/websocket before upgrading the connection to protect against CSWSH.

We previously relied on the package's default implementation, which only upgrades if the `Host` and `Origin`'s host within the request match.