### PR TITLE
Add Docker Support, Include Example Settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# builder
+FROM golang:latest AS builder
+
+RUN mkdir /app
+ADD . /app
+COPY . /app
+WORKDIR /app
+
+RUN go get
+RUN go build
+
+
+# runner
+FROM debian:buster-slim
+
+RUN mkdir /app
+WORKDIR /app/
+COPY --from=builder /app/chat .
+
+CMD ["./chat"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.4'
+services:
+  chat:
+    build:
+      context: ./chat
+      dockerfile: Dockerfile
+    container_name: dgg-chat
+    volumes:
+      - ./chat/settings.cfg:/app/settings.cfg:ro
+      - ./chat/state.dc:/app/state.dc
+    ports:
+      - "1118:1118"
+    restart: unless-stopped
+    depends_on:
+      - redis
+      - mariadb
+  redis:
+    image: redis
+    container_name: dgg-redis
+    volumes:
+      - ./data/redis:/data
+    restart: unless-stopped
+  mariadb:
+    image: mariadb:latest
+    container_name: dgg-mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD=rSlashJaydrVernandaFails
+      - MYSQL_DATABASE=destinygg
+    volumes:
+      - ./data/mariadb:/var/lib/mysql
+    restart: unless-stopped

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -1,0 +1,23 @@
+[default]
+debug = true
+listenaddress = 0.0.0.0:1118
+maxprocesses = 0
+chatdelay = 300000000
+maxthrottletime = 300000000000
+allowedoriginhost = www.destiny.gg
+
+[api]
+url = https://www.destiny.gg/api
+key = TonyW_JaydrVernanda
+
+[redis]
+address = dgg-redis:6379
+database = 0
+password =
+
+[database]
+type = mysql
+dsn = root:rSlashJaydrVernandaFails@tcp(dgg-mariadb:3306)/destiny_gg_fl?loc=UTC&parseTime=true&timeout=1s
+# ^ dont use root in prod, ever.
+# Schema: https://github.com/destinygg/website/blob/master/config/destiny.gg.sql
+# Data Init: https://github.com/destinygg/website/blob/master/config/destiny.gg.data.sql


### PR DESCRIPTION
* Adds Dockerfile for development without go installed
* Adds docker-compose for running the chatserver with required DB+Redis dependencies
* Example config file, because this is documented nowhere